### PR TITLE
Add TCP forwarding of detections to external tracker container

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -56,6 +56,11 @@ network:
     timing: 4001
     iqdata: 4002
     config: 4003
+  # Forward detections to external tracker container
+  tracker_forward:
+    enabled: false
+    host: 'blah2_tracker'
+    port: 3012
 
   node_id: "ret7dd2cb0d"
 


### PR DESCRIPTION
Enable the API to forward detection JSON to an external tracker container via TCP. This allows a separate tracker service to receive real-time detection data without modifying the C++ radar processor.

Configuration:
  network.tracker_forward.enabled: true/false
  network.tracker_forward.host: container hostname
  network.tracker_forward.port: TCP port (default 3012)

Features:
- Automatic reconnection on disconnect (5s retry)
- Disabled by default (no impact on existing deployments)
- Forwards complete detection JSON including ADS-B associations