### PR TITLE
Add TCP forwarding of detections to external tracker container

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -59,6 +59,12 @@ network:
 
   node_id: "ret7dd2cb0d"
 
+  # Forward detections to external tracker container
+  tracker_forward:
+    enabled: false
+    host: 'blah2_tracker'
+    port: 3012
+
 truth:
   adsb:
     enabled: true


### PR DESCRIPTION
Enable the API to forward detection JSON to an external tracker container via TCP. This allows a separate tracker service to receive real-time detection data without modifying the C++ radar processor.

Configuration:
  network.tracker_forward.enabled: true/false
  network.tracker_forward.host: container hostname
  network.tracker_forward.port: TCP port (default 3012)

Features:
- Automatic reconnection on disconnect (5s retry)
- Disabled by default (no impact on existing deployments)
- Forwards complete detection JSON including ADS-B associations