### PR TITLE
Reduce map polling interval from 100ms to 1000ms

### DIFF
--- a/web/html/js/plot_map.js
+++ b/web/html/js/plot_map.js
@@ -217,4 +217,4 @@ var intervalId = window.setInterval(function () {
     })
     .always(function () {
     });
-}, 100);
+}, 1000);


### PR DESCRIPTION
## Summary
- Reduces frontend polling interval from 100ms to 1000ms (1Hz)
- Prevents ERR_INSUFFICIENT_RESOURCES browser errors when server responses are slow

## Problem
The aggressive 100ms polling was causing request pile-up in Chrome socket pool when the server (especially on resource-constrained Pi 5 devices) could not respond fast enough. Each interval fires up to 4 concurrent requests:
- /api/timestamp
- /api/detection
- /api/adsb2dd
- /api/map

When response times exceed 100ms, requests accumulate until Chrome 6-connection-per-domain limit is exhausted.

## Test plan
- [ ] Verify map updates at 1Hz rate
- [ ] Confirm no ERR_INSUFFICIENT_RESOURCES errors in browser console under load
- [ ] Test on Pi 5 with high CPU usage

Generated with Claude Code