### PR TITLE
Add TCP push client for detection forwarding

### DIFF
--- a/api/server.js
+++ b/api/server.js
@@ -24,6 +24,9 @@ var stash_timing = require('./stash/timing.js');
 // TCP client for forwarding detections to external tracker
 let trackerSocket = null;
 let trackerConnected = false;
+const sendBuffer = [];
+let lastSendTime = 0;
+let heartbeatInterval = null;
 
 function connectToTracker() {
   if (!config.network.tracker_forward?.enabled) return;
@@ -32,10 +35,15 @@ function connectToTracker() {
   const port = config.network.tracker_forward.port;
 
   trackerSocket = new net.Socket();
+  trackerSocket.setNoDelay(true);
 
   trackerSocket.connect(port, host, () => {
     console.log(`Connected to tracker at ${host}:${port}`);
+    while (sendBuffer.length > 0) {
+      trackerSocket.write(sendBuffer.shift());
+    }
     trackerConnected = true;
+    lastSendTime = Date.now();
   });
 
   trackerSocket.on('error', (err) => {
@@ -51,13 +59,40 @@ function connectToTracker() {
 }
 
 function forwardToTracker(data) {
+  const framed = data + '\n';
   if (trackerConnected && trackerSocket) {
-    trackerSocket.write(data);
+    trackerSocket.write(framed);
+    lastSendTime = Date.now();
+  } else {
+    const bufferMax = config.network.tracker_forward.buffer_max || 1000;
+    if (sendBuffer.length >= bufferMax) {
+      sendBuffer.shift();
+    }
+    sendBuffer.push(framed);
   }
+}
+
+function startHeartbeat() {
+  if (!config.network.tracker_forward?.enabled) return;
+
+  const intervalSec = config.network.tracker_forward.heartbeat_interval_sec || 10;
+  const nodeId = config.network.node_id;
+  const token = config.network.tracker_forward.token || '';
+
+  heartbeatInterval = setInterval(() => {
+    if (!trackerConnected || !trackerSocket) return;
+    const elapsed = Date.now() - lastSendTime;
+    if (elapsed >= intervalSec * 1000) {
+      const msg = JSON.stringify({ node_id: nodeId, token: token, type: 'heartbeat' }) + '\n';
+      trackerSocket.write(msg);
+      lastSendTime = Date.now();
+    }
+  }, intervalSec * 1000);
 }
 
 // Initialize tracker connection
 connectToTracker();
+startHeartbeat();
 
 // constants
 const PORT = config.network.ports.api;
@@ -204,6 +239,10 @@ const server_detection = net.createServer((socket)=>{
               }
               return bestMatch;
             });
+          }
+          if (config.network.tracker_forward?.enabled) {
+            det.node_id = config.network.node_id;
+            det.token = config.network.tracker_forward.token || '';
           }
           detection = JSON.stringify(det);
           // Forward to external tracker if enabled

--- a/config/config.yml
+++ b/config/config.yml
@@ -69,6 +69,9 @@ network:
     enabled: false
     host: 'blah2_tracker'
     port: 3012
+    token: ''
+    buffer_max: 1000
+    heartbeat_interval_sec: 10
 
 truth:
   adsb:


### PR DESCRIPTION
## Summary

- Adds TCP push client to `api/server.js` that forwards detection frames to a remote tracker-host over persistent TCP connections
- Uses newline-delimited JSON framing with `node_id` and `token` in every frame
- Ring buffer (configurable `buffer_max`, default 1000) stores frames during disconnects, drains on reconnect
- Heartbeat keepalives every 10 seconds during idle periods
- TCP_NODELAY for low-latency forwarding
- Automatic reconnection with backoff on connection loss
- New config fields: `network.tracker_forward.token`, `buffer_max`, `heartbeat_interval_sec`

## Test plan

- [x] Tested locally with tracker-host TCP server and node simulator
- [ ] Deploy to a single test node first (Phase 2 of rollout)
- [ ] Run in dual-mode alongside HTTP polling to compare data streams
- [ ] Monitor reconnect behavior, buffer drain, heartbeat keepalives

🤖 Generated with [Claude Code](https://claude.com/claude-code)