### PR TITLE
20260601 - Fix RSPduo watchdog to target retina-node compose stack

### DIFF
--- a/script/blah2_rspduo_restart.bash
+++ b/script/blah2_rspduo_restart.bash
@@ -3,15 +3,18 @@
 # Run script with a crontab to automatically restart on error.
 # Checks the API to see if data is still being pushed through.
 
+COMPOSE_FILE=/data/mender-docker-compose/current/manifests/docker-compose.yaml
+PROJECT=retina-node
+
 FIRST_CHAR=$(curl -s 127.0.0.1:3000/api/map | head -c1)
 TIMESTAMP=$(curl -s 127.0.0.1:3000/api/map | head -c23 | tail -c10)
 CURR_TIMESTAMP=$(date +%s)
 DIFF_TIMESTAMP=$(($CURR_TIMESTAMP-$TIMESTAMP))
 
 if [[ "$FIRST_CHAR" != "{" ]] || [[ $DIFF_TIMESTAMP -gt 60 ]]; then
-  docker compose -f /opt/blah2/docker-compose.yml down
-  kill -9 $(pgrep -f "sdrplay_apiService")
+  docker compose -p $PROJECT -f $COMPOSE_FILE down
+  kill -9 $(pgrep -f "sdrplay_apiService") 2>/dev/null || true
   systemctl restart sdrplay.service
-  docker compose -f /opt/blah2/docker-compose.yml up -d
+  docker compose -p $PROJECT -f $COMPOSE_FILE up -d
   echo "Successfully restarted blah2"
 fi

--- a/script/crontab.txt
+++ b/script/crontab.txt
@@ -1,2 +1,3 @@
-# add to /etc/crontab
+# Deployed via owl-os radar_packages role to /etc/cron.d/blah2-rspduo-watchdog
+# RSPduo health check: restart retina-node stack if blah2 API data is stale (>60s)
 */5 * * * *     root    /opt/blah2/script/blah2_rspduo_restart.bash


### PR DESCRIPTION
## Fix RSPduo watchdog to target retina-node compose stack

### Summary

- Updated `blah2_rspduo_restart.bash` to use the `retina-node` Docker Compose project and its Mender-managed compose file path, replacing the hardcoded `/opt/blah2/docker-compose.yml` reference
- Made the `sdrplay_apiService` kill step non-fatal (`2>/dev/null || true`) so the restart sequence continues even if the process isn't running
- Improved `crontab.txt` comment to document the deployment path (`/etc/cron.d/blah2-rspduo-watchdog` via the `owl-os radar_packages` role) and describe the watchdog's purpose

The watchdog script was targeting the old standalone `blah2` compose stack. After migrating to the `retina-node` Mender-managed deployment, the restart sequence was failing because it couldn't find or control the correct stack.
