### PR TITLE
20260616 - Add independent gain reduction per RSPduo

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -10,7 +10,7 @@ capture:
     type: "RspDuo"
     agcSetPoint: -60
     bandwidthNumber: 0
-    gainReduction: 40 #20-59 dB, higher is less gain
+    gainReduction: [40, 40] #20-59 dB each, [reference, surveillance], higher is less gain
     lnaState: 4 #1-9, higher is more gain
     dabNotch: true
     rfNotch: true

--- a/config/config_test_diagnostic.yml
+++ b/config/config_test_diagnostic.yml
@@ -8,7 +8,7 @@ capture:
     type: "RspDuo"
     agcSetPoint: -60
     bandwidthNumber: 0
-    gainReduction: 40 #20-59 dB, higher is less gain
+    gainReduction: [40, 40] #20-59 dB each, [reference, surveillance], higher is less gain
     lnaState: 4 #1-9, higher is more gain
     dabNotch: true
     rfNotch: true

--- a/config/config_test_legacy.yml
+++ b/config/config_test_legacy.yml
@@ -8,7 +8,7 @@ capture:
     type: "RspDuo"
     agcSetPoint: -60
     bandwidthNumber: 0
-    gainReduction: 40 #20-59 dB, higher is less gain
+    gainReduction: [40, 40] #20-59 dB each, [reference, surveillance], higher is less gain
     lnaState: 4 #1-9, higher is more gain
     dabNotch: true
     rfNotch: true

--- a/config/sdr-variants/radar4.yml
+++ b/config/sdr-variants/radar4.yml
@@ -5,7 +5,7 @@ capture:
     type: "RspDuo"
     agcSetPoint: -20
     bandwidthNumber: 5
-    gainReduction: 59
+    gainReduction: [59, 59]
     lnaState: 1
     dabNotch: false
     rfNotch: false

--- a/src/capture/Capture.all.cpp
+++ b/src/capture/Capture.all.cpp
@@ -70,16 +70,17 @@ std::unique_ptr<Source> Capture::factory_source(const std::string& type, c4::yml
     // SDRplay RSPduo
     if (type == VALID_TYPE[0])
     {
-        int agcSetPoint, bandwidthNumber, gainReduction, lnaState;
+        int agcSetPoint, bandwidthNumber, gainReductionA, gainReductionB, lnaState;
         bool dabNotch, rfNotch;
         config["agcSetPoint"] >> agcSetPoint;
         config["bandwidthNumber"] >> bandwidthNumber;
-        config["gainReduction"] >> gainReduction;
+        config["gainReduction"][0] >> gainReductionA;
+        config["gainReduction"][1] >> gainReductionB;
         config["lnaState"] >> lnaState;
         config["dabNotch"] >> dabNotch;
         config["rfNotch"] >> rfNotch;
         return std::make_unique<RspDuo>(type, fc, fs, path, &saveIq,
-          agcSetPoint, bandwidthNumber, gainReduction, lnaState,
+          agcSetPoint, bandwidthNumber, gainReductionA, gainReductionB, lnaState,
           dabNotch, rfNotch);
     }
     // Usrp

--- a/src/capture/Capture.cpp
+++ b/src/capture/Capture.cpp
@@ -67,16 +67,17 @@ std::unique_ptr<Source> Capture::factory_source(const std::string& type, c4::yml
     // SDRplay RSPduo
     if (type == VALID_TYPE[0])
     {
-        int agcSetPoint, bandwidthNumber, gainReduction, lnaState;
+        int agcSetPoint, bandwidthNumber, gainReductionA, gainReductionB, lnaState;
         bool dabNotch, rfNotch;
         config["agcSetPoint"] >> agcSetPoint;
         config["bandwidthNumber"] >> bandwidthNumber;
-        config["gainReduction"] >> gainReduction;
+        config["gainReduction"][0] >> gainReductionA;
+        config["gainReduction"][1] >> gainReductionB;
         config["lnaState"] >> lnaState;
         config["dabNotch"] >> dabNotch;
         config["rfNotch"] >> rfNotch;
         return std::make_unique<RspDuo>(type, fc, fs, path, &saveIq,
-          agcSetPoint, bandwidthNumber, gainReduction, lnaState,
+          agcSetPoint, bandwidthNumber, gainReductionA, gainReductionB, lnaState,
           dabNotch, rfNotch, verbose);
     }
 

--- a/src/capture/rspduo/README.md
+++ b/src/capture/rspduo/README.md
@@ -8,7 +8,7 @@ Here is a list of available config parameters:
 
 - **bandwidthNumber** in Hz has a default value of 50 Hz, and can be 0, 5, 50 or 100 Hz. This is the number of times per second the AGC makes gain adjustments by changing the gain reduction value. If setting to 0 then the AGC is effectively disabled.
 
-- **gainReduction** in dB has a default value of 40 dB, and can be set between 20 and 59. This is the initial value the gain reduction is set to, before the AGC changes this parameter to approach the AGC set point.
+- **gainReduction** is a 2-element list `[tunerA, tunerB]` in dB, each with a default value of 40 dB and settable between 20 and 59. Tuner A feeds the reference channel and tuner B feeds the surveillance channel. This is the initial value the gain reduction is set to, before the AGC changes this parameter to approach the AGC set point.
 
 - **lnaState** has a default value of 4, must be between 1 and 9. A larger number means a larger gain reduction (attenuation). Maximum gain at LNA state 1 and minimum gain at LNA state 9.
 

--- a/src/capture/rspduo/RspDuo.cpp
+++ b/src/capture/rspduo/RspDuo.cpp
@@ -45,7 +45,7 @@ IqData *buffer2;
 RspDuo::RspDuo(std::string _type, uint32_t _fc,
   uint32_t _fs, std::string _path, bool *_saveIq,
   int _agcSetPoint, int _bandwidthNumber,
-  int _gainReduction, int _lnaState,
+  int _gainReductionA, int _gainReductionB, int _lnaState,
   bool _dabNotch, bool _rfNotch, bool _verbose)
   : Source(_type, _fc, _fs, _path, _saveIq)
 {
@@ -82,7 +82,8 @@ RspDuo::RspDuo(std::string _type, uint32_t _fc,
   saveIqFileLocal = &saveIqFile;
   agc_bandwidth_nr = _bandwidthNumber;
   agc_set_point_nr = _agcSetPoint;
-  gain_reduction_nr = _gainReduction;
+  gain_reduction_nr_a = _gainReductionA;
+  gain_reduction_nr_b = _gainReductionB;
   lna_state_nr = _lnaState;
   rf_notch_fg = _rfNotch;
   dab_notch_fg = _dabNotch;
@@ -107,6 +108,23 @@ void RspDuo::process(IqData *_buffer1, IqData *_buffer2)
   buffer2 = _buffer2;
 
   initialise_device();
+
+  // update gains after initialization
+  if ((err = sdrplay_api_Update(chosenDevice->dev, sdrplay_api_Tuner_A,
+                      sdrplay_api_Update_Tuner_Gr,
+                      sdrplay_api_Update_Ext1_None)) != sdrplay_api_Success) {
+      std::cerr << "Failed to update Tuner A gain: " << sdrplay_api_GetErrorString(err) << std::endl;
+      sdrplay_api_Close();
+      exit(1);
+  }
+
+  if ((err = sdrplay_api_Update(chosenDevice->dev, sdrplay_api_Tuner_B,
+                    sdrplay_api_Update_Tuner_Gr,
+                    sdrplay_api_Update_Ext1_None)) != sdrplay_api_Success) {
+      std::cerr << "Failed to update Tuner B gain: " << sdrplay_api_GetErrorString(err) << std::endl;
+      sdrplay_api_Close();
+      exit(1);
+  }
 
   // control loop
   while (run_fg)
@@ -181,7 +199,11 @@ void RspDuo::validate() {
     }
 
     // validate LNA
-    if (gain_reduction_nr < MIN_GAIN_REDUCTION_NR || gain_reduction_nr > MAX_GAIN_REDUCTION_NR) {
+    if (gain_reduction_nr_a < MIN_GAIN_REDUCTION_NR || gain_reduction_nr_a > MAX_GAIN_REDUCTION_NR) {
+        std::cerr << "Error: Gain reduction must be between " << MIN_GAIN_REDUCTION_NR << " and " << MAX_GAIN_REDUCTION_NR << std::endl;
+        exit(1);
+    }
+    if (gain_reduction_nr_b < MIN_GAIN_REDUCTION_NR || gain_reduction_nr_b > MAX_GAIN_REDUCTION_NR) {
         std::cerr << "Error: Gain reduction must be between " << MIN_GAIN_REDUCTION_NR << " and " << MAX_GAIN_REDUCTION_NR << std::endl;
         exit(1);
     }
@@ -199,7 +221,8 @@ void RspDuo::validate() {
     std::cerr << "file                          : " << file.c_str() << std::endl;
     std::cerr << "agc_bandwidth_nr (Hz)         : " << agc_bandwidth_nr << std::endl;
     std::cerr << "agc_set_point_nr (dBfs)       : " << agc_set_point_nr << std::endl;
-    std::cerr << "gain_reduction_nr (dB)        : " << gain_reduction_nr << std::endl;
+    std::cerr << "gain_reduction_nr_a (dB)      : " << gain_reduction_nr_a << std::endl;
+    std::cerr << "gain_reduction_nr_b (dB)      : " << gain_reduction_nr_b << std::endl;
     std::cerr << "lna_state_nr                  : " << lna_state_nr << std::endl;
     std::cerr << "N_DECIMATION                  : " << nDecimation << std::endl;
     std::cerr << "rf_notch_fg                   : " << (rf_notch_fg ? "true" : "false") << std::endl;
@@ -394,8 +417,10 @@ void RspDuo::set_device_parameters()
   }
 
   // set gain reduction and lna sate
-  chParams->tunerParams.gain.gRdB = gain_reduction_nr;
-  chParams->tunerParams.gain.LNAstate = lna_state_nr;
+  deviceParams->rxChannelA->tunerParams.gain.gRdB = gain_reduction_nr_a;
+  deviceParams->rxChannelA->tunerParams.gain.LNAstate = lna_state_nr;
+  deviceParams->rxChannelB->tunerParams.gain.gRdB = gain_reduction_nr_b;
+  deviceParams->rxChannelB->tunerParams.gain.LNAstate = lna_state_nr;
 
   // set decimation and IF frequency and analog bandwidth
   chParams->ctrlParams.decimation.enable = 1;

--- a/src/capture/rspduo/RspDuo.h
+++ b/src/capture/rspduo/RspDuo.h
@@ -35,8 +35,10 @@ private:
   int agc_bandwidth_nr;
   /// @brief AGC set point (dBfs)
   int agc_set_point_nr;
-  /// @brief Gain reduction (dB).
-  int gain_reduction_nr;
+  /// @brief Gain reduction for tuner A / reference channel (dB).
+  int gain_reduction_nr_a;
+  /// @brief Gain reduction for tuner B / surveillance channel (dB).
+  int gain_reduction_nr_b;
   /// @brief LNA state
   int lna_state_nr;
   /// @brief Decimation factor (integer).
@@ -162,7 +164,7 @@ public:
   /// @return The object.
   RspDuo(std::string type, uint32_t fc, uint32_t fs,
     std::string path, bool *saveIq, int agcSetPoint,
-    int bandwidthNumber, int gainReduction,
+    int bandwidthNumber, int gainReductionA, int gainReductionB,
     int lnaState, bool dabNotch, bool rfNotch, bool verbose = false);
 
   /// @brief Implement capture function on RSPduo.


### PR DESCRIPTION
# Add independent gain reduction per RSPduo tuner

## Summary

- Ports a feature from upstream `30hours/blah2` that we were missing: the RSPduo's two tuners can now be given independent gain reduction values instead of being forced to share one.
- Tuner A (reference channel) and Tuner B (surveillance channel) are validated and applied independently, with explicit `sdrplay_api_Update()` calls after device init so the values actually take effect on both tuners.
- `gainReduction` in config is now a 2-element list `[tunerA, tunerB]` instead of a single scalar — **this is a breaking config format change**, not backward compatible.

## Why

blah2 listens to a reference signal (direct from the illuminator, usually strong) and a surveillance signal (weak target echoes) on the RSPduo's two tuners. Forcing one shared gain value meant compromising between clipping the reference channel and starving the surveillance channel of dynamic range. Independent gain per tuner removes that compromise.

## Changes

- `src/capture/rspduo/RspDuo.h` / `.cpp` — split `gain_reduction_nr` into `gain_reduction_nr_a`/`_b`; both validated against the existing 20–59 dB bound; both written to `rxChannelA`/`rxChannelB`; added two `sdrplay_api_Update()` calls (Tuner A, Tuner B) in `process()` after `initialise_device()`.
- `src/capture/Capture.cpp` and `src/capture/Capture.all.cpp` (parallel factory used by the `all` build target) — read `gainReduction[0]`/`[1]` instead of a scalar.
- `config/config.yml`, `config_test_diagnostic.yml`, `config_test_legacy.yml`, `config/sdr-variants/radar4.yml` — updated to `gainReduction: [a, b]`.
- `src/capture/rspduo/README.md` — documented the new list format and which tuner maps to which channel.

## Risks

- **Not yet tested on physical RSPduo hardware.** The two new `sdrplay_api_Update()` calls are a new failure path — previously gain was just an in-memory struct write that couldn't fail; now it's a live driver call made after streaming has already started, which can return an error and `exit(1)`.
- The `blah2` container runs `restart: always` with no healthcheck defined, and neither `sdrplay-restart.sh` nor the cron watchdog (`script/blah2_rspduo_restart.bash`) can distinguish a deterministic API failure from ordinary data staleness — both would just keep restarting a binary that may never come up cleanly.
- This needs to land together with the corresponding `retina-node` config default update — an old scalar `gainReduction` value against this binary will throw during YAML parsing.

## Test plan

- [x] `g++ -fsyntax-only` against the vendored SDRplay 3.15.2 headers — compiles cleanly.
- [ ] Full build via the normal CI/dev image pipeline (not verified in dev sandbox — missing ARM toolchain/vcpkg deps).
- [ ] Manual supervised test on physical RSPduo: `docker compose up` in the foreground, confirm no `"Failed to update Tuner A/B gain"` errors in the logs, confirm map/detections come up normally with independent gain values set.
